### PR TITLE
Switch build-backend to poetry-core

### DIFF
--- a/pyproject-whl.toml
+++ b/pyproject-whl.toml
@@ -62,5 +62,5 @@ python = ">=2.6 || >=3.0"
 pytest = "==6.0.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,5 +62,5 @@ python = ">=2.6 || >=3.0"
 pytest = "==6.0.1"
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
poetry-core is the lightweight counterpart of poetry that is intended
to be used as a build-backend.  Unlike poetry, it does not require
installing all the dependencies of the package manager, making
the builds much faster.  The generated artifacts are the same.